### PR TITLE
Fix class names to start with uppercase (#19)

### DIFF
--- a/app/src/main/java/com/example/todoapp/holidays/data/network/HoliDays.kt
+++ b/app/src/main/java/com/example/todoapp/holidays/data/network/HoliDays.kt
@@ -1,6 +1,6 @@
 package com.example.todoapp.holidays.data.network
 
-import com.example.todoapp.holidays.data.network.response.holiDaysResponse
+import com.example.todoapp.holidays.data.network.response.HoliDaysResponse
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -8,9 +8,9 @@ import retrofit2.http.Query
 interface HoliDays {
     // Método existente para obtener todas las festividades
     @GET("/festividades")
-    suspend fun holidays(): Response<List<holiDaysResponse>>
+    suspend fun holidays(): Response<List<HoliDaysResponse>>
 
     // Nuevo método para obtener las festividades de una fecha específica
     @GET("/festividad")
-    suspend fun holidayByDate(@Query("fecha") fecha: String): Response<holiDaysResponse>
+    suspend fun holidayByDate(@Query("fecha") fecha: String): Response<HoliDaysResponse>
 }

--- a/app/src/main/java/com/example/todoapp/holidays/data/network/HoliDaysService.kt
+++ b/app/src/main/java/com/example/todoapp/holidays/data/network/HoliDaysService.kt
@@ -1,14 +1,14 @@
 package com.example.todoapp.holidays.data.network
 
 import com.example.todoapp.core.network.RetrofitHelper
-import com.example.todoapp.holidays.data.network.response.holiDaysResponse
+import com.example.todoapp.holidays.data.network.response.HoliDaysResponse
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class HoliDaysService {
     private val retrofit = RetrofitHelper.getRetrofit()
 
-    suspend fun holidays(): List<holiDaysResponse>? {
+    suspend fun holidays(): List<HoliDaysResponse>? {
         return withContext(Dispatchers.IO) {
             val response = retrofit.create(HoliDays::class.java).holidays()
             if (response.isSuccessful) {
@@ -19,7 +19,7 @@ class HoliDaysService {
         }
     }
 
-    suspend fun holidayByDate(fecha: String): holiDaysResponse? {
+    suspend fun holidayByDate(fecha: String): HoliDaysResponse? {
         return withContext(Dispatchers.IO) {
             val response = retrofit.create(HoliDays::class.java).holidayByDate(fecha)
             if (response.isSuccessful) {

--- a/app/src/main/java/com/example/todoapp/holidays/data/network/response/HoliDaysResponse.kt
+++ b/app/src/main/java/com/example/todoapp/holidays/data/network/response/HoliDaysResponse.kt
@@ -2,7 +2,7 @@ package com.example.todoapp.holidays.data.network.response
 
 import com.google.gson.annotations.SerializedName
 
-data class holiDaysResponse(
+data class HoliDaysResponse(
     @SerializedName("fecha") val fecha: String, // Representa la fecha en formato String
     @SerializedName("nombre") val nombre: String // Representa el nombre del día festivo
 )


### PR DESCRIPTION
Corrected class names to follow naming conventions by starting with an uppercase letter, as per the project's style guide.
Closes #19.